### PR TITLE
Swapped out '/' for DIRECTORY_SEPARATOR to support windows

### DIFF
--- a/src/CommandTranslationGenerator.php
+++ b/src/CommandTranslationGenerator.php
@@ -74,7 +74,7 @@ final class CommandTranslationGenerator extends Command
         $directories = File::directories(lang_path());
 
         foreach ($directories as $dir) {
-            $path = str_replace(lang_path() . '/', '', $dir);
+            $path = str_replace(lang_path() . DIRECTORY_SEPARATOR, '', $dir);
             $locales[] = $path;
         }
 


### PR DESCRIPTION
CommandTranslationGenerator::generate method

        foreach ($directories as $dir) {
            $path = str_replace(lang_path() . '/', '', $dir);
            $locales[] = $path;
        }

Swapped to:

        foreach ($directories as $dir) {
            $path = str_replace(lang_path() . DIRECTORY_SEPARATOR, '', $dir);
            $locales[] = $path;
        }