### PR TITLE
Fixes for translations with choices

### DIFF
--- a/dist/translator.js
+++ b/dist/translator.js
@@ -52,7 +52,7 @@ const pluralize = (sentence, count) => {
     let parts = sentence.split('|')
 
     //Get SOLO number pattern parts
-    const soloPattern = /{(?<count>\d)}[^\|]*/g
+    const soloPattern = /{(?<count>\d+\.?\d*)}[^\|]*/g
     const soloParts = parts.map(part => {
         let matched = [...part.matchAll(soloPattern)]
         if (matched.length <= 0) {
@@ -60,7 +60,7 @@ const pluralize = (sentence, count) => {
         }
         matched = matched[0]
         return {
-            count: parseInt(matched[1]),
+            count: 1*matched[1],
             value: stripConditions(matched[0]).trim()
         }
     }).filter((o) => o !== undefined)

--- a/dist/translator.js
+++ b/dist/translator.js
@@ -1,5 +1,5 @@
 export const trans = (key, replace, pluralize, config) => {
-    const locale = config.locale
+    const locale = config.locale.toLowerCase()
     const Lingua = config.Lingua
 
     let translation = null

--- a/dist/translator.js
+++ b/dist/translator.js
@@ -102,7 +102,7 @@ const pluralize = (sentence, count) => {
 
     if(trans.length > 1){
         const index = count == 1 ? 0 : 1;
-        return parts[index]
+        return parts[index] ?? parts[0]
     }
 
     return sentence

--- a/dist/translator.js
+++ b/dist/translator.js
@@ -31,7 +31,6 @@ export const trans = (key, replace, pluralize, config) => {
 
 const translate = (translation, replace, shouldPluralize) => {
     let translated = shouldPluralize ? pluralize(translation, replace.count) : translation
-
     if (typeof replace === 'undefined') {
         return translation
     }
@@ -44,6 +43,10 @@ const translate = (translation, replace, shouldPluralize) => {
     return translated
 }
 
+const stripConditions = (sentence) => {
+    const ret =  sentence.replace(/^[\{\[]([^\[\]\{\}]*)[\}\]]/, '')
+    return ret
+}
 
 const pluralize = (sentence, count) => {
     let parts = sentence.split('|')
@@ -58,7 +61,7 @@ const pluralize = (sentence, count) => {
         matched = matched[0]
         return {
             count: parseInt(matched[1]),
-            value: matched[0].replace(`{${matched[1]}}`, '').trim()
+            value: stripConditions(matched[0]).trim()
         }
     }).filter((o) => o !== undefined)
     let i = 0;
@@ -102,7 +105,7 @@ const pluralize = (sentence, count) => {
 
     if(trans.length > 1){
         const index = count == 1 ? 0 : 1;
-        return parts[index] ?? parts[0]
+        return stripConditions(parts[index] ?? parts[0]).trim()
     }
 
     return sentence

--- a/dist/translator.js
+++ b/dist/translator.js
@@ -75,7 +75,7 @@ const pluralize = (sentence, count) => {
     }
 
     //Get ranged pattern parts
-    const rangedPattern = /\[(?<start>\d+),(?<end>\d+|\*)][^\|]*/g
+    const rangedPattern = /\[(?<start>\d+|\*),(?<end>\d+|\*)][^\|]*/g
     const rangedParts = parts.map(part => {
         let matched = [...part.matchAll(rangedPattern)]
         if (matched.length <= 0) {
@@ -94,7 +94,7 @@ const pluralize = (sentence, count) => {
     while (i < rangedParts.length) {
         const p = rangedParts[i]
 
-        if (count >= p.start) {
+        if (count >= p.start || isNaN(p.start)) {
             if (count <= p.end || p.end === true) {
                 return p.value
             }

--- a/tests/trans-choice.test.js
+++ b/tests/trans-choice.test.js
@@ -114,3 +114,13 @@ it.each(laravelTranslationMessageSelectorTestData)('passes laravel test case [%s
     const result = trans(message, { count: number }, true, config)
     expect(result).toBe(expected)
 });
+
+
+/*
+test.only('one-by-one', () => {
+    const [expected, message, number] = ['first', '{0}  first|{1}second', 0]
+    console.log(expected, message, number, 'CASE')
+    const result = trans(message, { count: number }, true, config)
+    expect(result).toBe(expected)
+})
+*/

--- a/tests/trans-choice.test.js
+++ b/tests/trans-choice.test.js
@@ -59,3 +59,58 @@ test('trans is returning first choice option with replace', () => {
 test('trans is returning second choice option with replace', () => {
     expect(trans('replace', { count: 20 }, true, config)).toBe('There are 20 users online')
 });
+
+// These are the test cases from the laravel framework, class Illuminate\Tests\Translation\TranslationMessageSelectorTest
+// format: [expected, message, number]
+const laravelTranslationMessageSelectorTestData = [
+    ['first', 'first', 1],
+    ['first', 'first', 10],
+    ['first', 'first|second', 1],
+    ['second', 'first|second', 10],
+    ['second', 'first|second', 0],
+
+    ['first', '{0}  first|{1}second', 0],
+    ['first', '{1}first|{2}second', 1],
+    ['second', '{1}first|{2}second', 2],
+    ['first', '{2}first|{1}second', 2],
+    ['second', '{9}first|{10}second', 0],
+    ['first', '{9}first|{10}second', 1],
+    ['', '{0}|{1}second', 0],
+    ['', '{0}first|{1}', 1],
+    ['first', '{1.3}first|{2.3}second', 1.3],
+    ['second', '{1.3}first|{2.3}second', 2.3],
+    [`first
+    line`, `{1}first
+    line|{2}second`, 1],
+    [`first \n
+    line`, `{1}first \n
+    line|{2}second`, 1],
+
+    ['first', '{0}  first|[1,9]second', 0],
+    ['second', '{0}first|[1,9]second', 1],
+    ['second', '{0}first|[1,9]second', 10],
+    ['first', '{0}first|[2,9]second', 1],
+    ['second', '[4,*]first|[1,3]second', 1],
+    ['first', '[4,*]first|[1,3]second', 100],
+    ['second', '[1,5]first|[6,10]second', 7],
+    ['first', '[*,4]first|[5,*]second', 1],
+    ['second', '[5,*]first|[*,4]second', 1],
+    ['second', '[5,*]first|[*,4]second', 0],
+
+    ['first', '{0}first|[1,3]second|[4,*]third', 0],
+    ['second', '{0}first|[1,3]second|[4,*]third', 1],
+    ['third', '{0}first|[1,3]second|[4,*]third', 9],
+
+    ['first', 'first|second|third', 1],
+    ['second', 'first|second|third', 9],
+    ['second', 'first|second|third', 0],
+
+    ['first', '{0}  first | { 1 } second', 0],
+    ['first', '[4,*]first | [1,3]second', 100],
+
+]
+
+it.each(laravelTranslationMessageSelectorTestData)('passes laravel test case [%s, %s, %s]', (expected, message, number) => {
+    const result = trans(message, { count: number }, true, config)
+    expect(result).toBe(expected)
+});


### PR DESCRIPTION
Many thanks for this useful package - a good integration of laravel translation strings has been a gap in the inertia/vue ecosystem for a long time!

I noticed that a couple of strings with choices were translated differently in the lingua package than in laravel. 

To solve this problem, I added the [test cases from the laravel TranslationMessageSelectorTest.php](https://github.com/laravel/framework/blob/10.x/tests/Translation/TranslationMessageSelectorTest.php) to this project. After adding the test cases, four tests were failing which are fixed in this PR:

- [['first', 'first', 10]](https://github.com/cyberwolf-studio/lingua/commit/489bf78e61708f747436e98acd456c6139d44de7)
- [['second', '{9}first|{10}second', 0]](https://github.com/cyberwolf-studio/lingua/commit/ff9138903383b4fa1ab66fde16c4bd19ee8645d3)
- [['second', '[5,*]first|[*,4]second', 1]](https://github.com/cyberwolf-studio/lingua/commit/b5ca14754eb0b65c10b3296f31c511e279ac525b)
- [['first', '{1.3}first|{2.3}second', 1.3]](https://github.com/cyberwolf-studio/lingua/commit/52f9d2e6aebed452ff7718df57cd6578b6baab97)

Where the first element is the expected result for the translation of the second argument when evaluated with the count from the last argument.

