### PR TITLE
fix: trans should translate keys containg dot character

### DIFF
--- a/dist/translator.js
+++ b/dist/translator.js
@@ -5,8 +5,9 @@ export const trans = (key, replace, pluralize, config) => {
     let translation = null
 
     try {
-        translation = key
-            .split('.')
+        translation =
+            Lingua.translations[locale].php?.[key] ??
+            key.split('.')
             .reduce((t, i) => t[i] || null, Lingua.translations[locale].php)
 
         if (translation) {
@@ -16,8 +17,9 @@ export const trans = (key, replace, pluralize, config) => {
     }
 
     try {
-        translation = key
-            .split('.')
+        translation =
+            Lingua.translations[locale].json?.[key] ??
+            key.split('.')
             .reduce((t, i) => t[i] || null, Lingua.translations[locale].json)
 
         if (translation) {

--- a/tests/trans.test.js
+++ b/tests/trans.test.js
@@ -21,7 +21,8 @@ const Lingua = {
         },
         pl: {
             php: {
-                dashboard: 'Panel'
+                dashboard: 'Panel',
+                "Please enter your email address.": "Proszę podaj swój adres email.",
             }
         }
     }
@@ -38,6 +39,16 @@ test('trans is translating string', () => {
 
 test('trans is translating nested object', () => {
     expect(trans('settings.title', {}, false, config)).toBe('Settings')
+});
+
+test("trans is translating key containing dot character", () => {
+    const configPl = {
+        Lingua: Lingua,
+        locale: "pl",
+    };
+    expect(trans("Please enter your email address.", {}, false, configPl)).toBe(
+        "Proszę podaj swój adres email."
+    );
 });
 
 test('trans is replacing key', () => {


### PR DESCRIPTION
This pull request addresses an issue where translation keys containing the dot (.) character were not being properly translated.

In Laravel projects, it’s common to directly translate strings - which may be full sentences or even multiple sentences - without utilizing translation keys, as seen in this example: https://github.com/Laravel-Lang/lang/blob/main/locales/de/json.json#L27. Without this fix, these strings will not be translated.