### PR TITLE
Import required class

### DIFF
--- a/src/Commands/Generate.php
+++ b/src/Commands/Generate.php
@@ -2,6 +2,7 @@
 
 namespace CyberWolfStudio\Lingua\Commands;
 
+use CyberWolfStudio\Lingua\TranslationPayload;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;


### PR DESCRIPTION
When running `./artisan lingua:generate` on v1.0.0, it crashed on a missing class `TranslationPayload`. 

This PR fixes this by adding the correct import.
